### PR TITLE
Add server mischief

### DIFF
--- a/server/static/mischief.html
+++ b/server/static/mischief.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>OTC Mischief</title>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,600' rel='stylesheet' type='text/css'>
+  <style type="text/css">
+    body, h1 {
+      font-family: "Open Sans", sans-serif;
+      margin: 0;
+      padding: 0;
+    }
+    header {
+      color: white;
+      background-color: #0E0513;
+      text-align: center;
+      padding: 10px;
+    }
+    section {
+      color: #222;
+      margin: 20px;
+      border: none;
+      border-bottom: 1px solid #0E0513;
+      padding-bottom: 30px;
+    }
+    main {
+      max-width: 1000px;
+      margin: 0 auto;
+    }
+    form label {
+      margin-right: 10px;
+    }
+    form input.userid {
+      width: 80px;
+    }
+  </style>
+</head>
+
+<body>
+  <header>
+    <h1>OTC Mischief Control Panel</h1>
+  </header>
+  <main>
+  <section>
+    <h2>Drop Message</h2>
+    <p>Drop the last message for a user.</p>
+    <form action="/mischief" method="post">
+        <label for="userid">UserID:</label>
+        <input class="userid" type="text" name="userid">
+        <input type="hidden" name="kind" value="drop">
+        <input type="submit" value="Drop">
+    </form>
+  </section>
+  <section>
+    <h2>Corrupt Message</h2>
+    <p>Flip a few random bits in the last message for a user.</p>
+    <form action="/mischief" method="post">
+        <label for="userid">UserID:</label>
+        <input class="userid" type="text" name="userid">
+        <input type="hidden" name="kind" value="corrupt">
+        <input type="submit" value="Corrupt">
+    </form>
+  </section>
+  <!--
+  <section>
+    <h2>Clear Messages</h2>
+    <p>Forget all messages for a user.</p>
+    <form action="/mischief" method="post">
+        <label for="userid">UserID:</label>
+        <input class="userid" type="text" name="userid">
+        <input type="hidden" name="kind" value="clear">
+        <input type="submit" value="Clear">
+    </form>
+  </section>
+  -->
+  </main>
+</body>
+</html>


### PR DESCRIPTION
This adds a page where an attacker (anyone) can perform mischief on the messages to be delivered.
- drop last message for a user
- corrupt some of the last message for a user.

You can access these buttons by going to http://server:port/mischief in your web browser. There are forms that take a user ID and cause a drop or corruption.
