### PR TITLE
Add cursor memory to device.

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -97,10 +97,13 @@ class OTC_Client(object):
 
         device_nextref = self.rpc_client.get_next_ref(self.user_id, self.server_address)
 
+        if server_nextref == None and device_nextref == None:
+            return 0
         if server_nextref == None:
             return device_nextref
-        else:
-            return min(server_nextref, device_nextref)
+        if device_nextref == None:
+            return server_nextref
+        return min(server_nextref, device_nextref)
 
     def save_next_ref(self):
         """Save the next ref setting to the device."""

--- a/device/jsonstore.py
+++ b/device/jsonstore.py
@@ -1,0 +1,23 @@
+import json
+
+class JsonStore(object):
+    """
+    Store json in a file.
+    """
+    def __init__(self, filepath):
+        self.filepath = filepath
+        self.data = {}
+
+    def read(self):
+        try:
+            with open(self.filepath, "r") as f:
+                self.data = json.load(f)
+        except (IOError, ValueError):
+            self.data = {}
+
+    def write(self):
+        with open(self.filepath, "w") as f:
+            json.dump(self.data, f,
+                      sort_keys=True,
+                      indent=4,
+                      separators=(",", ": "))

--- a/device/rpcmethods.py
+++ b/device/rpcmethods.py
@@ -137,7 +137,7 @@ def get_next_ref(uid, server_address):
     """
     store = JsonStore("nextref.json")
     store.read()
-    return store.data.get(uid, {}).get(server_address, 0)
+    return store.data.get(uid, {}).get(server_address, None)
 
 def save_next_ref(uid, server_address, nextref):
     """Save the nextref setting for a (user, server) pair."""


### PR DESCRIPTION
Add cursor (ref) memory to the device.

This is nice because you can now get messages after you have been offline.

When the client starts it picks a start_ref like this:
Fetch ref for user from server.
Fetch ref for (user, server_address) pair from device.
If only one of these exists, use that one.
If both exist, use the minimum of the two.
If neither exist, use 0.

Whenever the ref changes, set the according (user, server_address) pair on the device to the new one.
